### PR TITLE
Use HTML5 to give web UI command input focus after refrsh

### DIFF
--- a/cgibin.c
+++ b/cgibin.c
@@ -301,7 +301,7 @@ int     msgcount = 22;
     hprintf(webblk->sock, "</PRE>\n");
 
     hprintf(webblk->sock, "<FORM method=post>Command:\n");
-    hprintf(webblk->sock, "<INPUT type=text name=command size=80>\n");
+    hprintf(webblk->sock, "<INPUT type=text name=command size=80 autofocus>\n");
     hprintf(webblk->sock, "<INPUT type=submit name=send value=\"Send\">\n");
     hprintf(webblk->sock, "<INPUT type=hidden name=%srefresh value=1>\n",autorefresh ? "auto" : "no");
     hprintf(webblk->sock, "<INPUT type=hidden name=refresh_interval value=%d>\n",refresh_interval);


### PR DESCRIPTION
The existing behavior cursor focus of the web interface for the hercules console is not defined and not useful.  This change places the focus in the command line box, which is where the user is most likely to type.