### PR TITLE
setting memtab[n].multixt explicit to 0 in dasdisup.c

### DIFF
--- a/dasdisup.c
+++ b/dasdisup.c
@@ -338,7 +338,9 @@ char            memnama[9];             /* Member name (ASCIIZ)      */
                     _("HHCDS006W Member %s is not single text record\n"),
                     memnama);
             memtab[n].multitxt = 1;
-        }
+        } else {
+			memtab[n].multitxt = 0;
+		}
 
         /* Check that the total module length does not exceed X'7F8' */
         if (totlen > 255*8)

--- a/dasdisup.c
+++ b/dasdisup.c
@@ -339,8 +339,8 @@ char            memnama[9];             /* Member name (ASCIIZ)      */
                     memnama);
             memtab[n].multitxt = 1;
         } else {
-			memtab[n].multitxt = 0;
-		}
+            memtab[n].multitxt = 0;
+        }
 
         /* Check that the total module length does not exceed X'7F8' */
         if (totlen > 255*8)


### PR DESCRIPTION
as it hasn't been initialized before, causing errors if the memtab-memory hasn't been zeroed in the malloc call at the line 641, which isn't guaranteed.

At least on my machine dasdisup didn't work (in the current version, mysteriously or perhaps luckily it worked in the version 3.07) because of this bug.
Consequently generating and running of OS360 (http://www.conmicro.com/hercos360) didn't work too.