### PR TITLE
CTCE device corrections and improvements, connect() timeout reduced; EQID corrected; IPTE fixed

### DIFF
--- a/ctcadpt.c
+++ b/ctcadpt.c
@@ -46,13 +46,15 @@ typedef struct _CTCE_INFO
     BYTE               de_ready;       /* Device-End status          */
                                        /* indicating ready to be     */
                                        /* presented, yielding ...    */
-    BYTE               sent;           /* = 1 if CTCE_Send done      */
+    u_int              sent : 1;       /* = 1 : CTCE_Send done       */
+    u_int              attn_can : 1;   /* = 1 : Atttention Cancelled */
+    u_int              con_lost : 1;   /* = 1 : contention lost      */
+    u_int              con_won  : 1;   /* = 1 : contention won       */
     int                wait_rc;        /* CTCE_Send Wait RC if used  */
     int                de_ready_attn_rc;   /* device_attention RC    */
     int                working_attn_rc;    /* device_attention RC    */
                                        /* from transition to         */
                                        /* "Working(D)" state         */
-    int                working_attn_retry; /* retry count for this   */
     int                sok_buf_len;    /* socket buffer length       */
 }
 CTCE_INFO;
@@ -111,6 +113,11 @@ static void     CTCE_Trace( const DEVBLK*             pDEVBLK,
                             const CTCE_INFO*          pCTCE_Info,
                             const BYTE*               pCTCE_Buf,
                             const BYTE*               pUnitStat );
+
+static int      CTCE_Connect_Timeout( int                    sockfd,
+                                      const struct sockaddr* saptr,
+                                      const socklen_t        salen,
+                                      const int              usec );
 
 static int      VMNET_Init( DEVBLK *dev, int argc, char *argv[] );
 
@@ -197,15 +204,15 @@ static char *CTCE_CmdStr[16] = {
     "SBM"   // 15 = 17 = Set Basic Mode
 };
 
-static BYTE CTCE_Cmd[256] = {
+static BYTE CTCE_command[256] = {
     14, 3, 2, 8,10, 3, 2, 1,13, 3, 2, 8, 6, 3, 2, 1,
     13, 3, 2, 8, 4, 3, 2, 1,13, 3, 2, 8, 6, 3, 2, 1,
     13, 3, 2, 8,13, 3, 2, 1,13, 3, 2, 8, 6, 3, 2, 1,
     13, 3, 2, 8, 4, 3, 2, 1,13, 3, 2, 8, 6, 3, 2, 1,
-    13, 3, 2,15,13, 3, 2, 1,13, 3, 2,13, 6, 3, 2, 1,
-    13, 3, 2,15, 4, 3, 2, 1,13, 3, 2,13, 6, 3, 2, 1,
-    13, 3, 2,15,13, 3, 2, 1,13, 3, 2,13, 6, 3, 2, 1,
-    13, 3, 2,15, 4, 3, 2, 1,13, 3, 2,13, 6, 3, 2, 1,
+    13, 3, 2,15,13, 3, 2, 1,13, 3, 2,15, 6, 3, 2, 1,
+    13, 3, 2,15, 4, 3, 2, 1,13, 3, 2,15, 6, 3, 2, 1,
+    13, 3, 2,15,13, 3, 2, 1,13, 3, 2,15, 6, 3, 2, 1,
+    13, 3, 2,15, 4, 3, 2, 1,13, 3, 2,15, 6, 3, 2, 1,
     13, 7, 2, 8,13, 7, 2, 1,13, 7, 2, 8, 6, 7, 2, 1,
     13, 7, 2, 8, 4, 7, 2, 1,13, 7, 2, 8, 6, 7, 2, 1,
     13, 7, 2, 8,13, 7, 2, 1,13, 7, 2, 8, 6, 7, 2, 1,
@@ -216,21 +223,29 @@ static BYTE CTCE_Cmd[256] = {
     13, 7, 2,13, 4, 7, 2, 1,13, 7, 2,13, 6, 7, 2, 1
 };
 
-#define IS_CTCE_CCW_PRE(c)      ((CTCE_Cmd[c]==0))
-#define IS_CTCE_CCW_CTL(c)      ((CTCE_Cmd[c]==1))
-#define IS_CTCE_CCW_RED(c)      ((CTCE_Cmd[c]==2))
-#define IS_CTCE_CCW_WRT(c)      ((CTCE_Cmd[c]==3))
-#define IS_CTCE_CCW_SCB(c)      ((CTCE_Cmd[c]==4))
-#define IS_CTCE_CCW_RBK(c)      ((CTCE_Cmd[c]==6))
-#define IS_CTCE_CCW_WEF(c)      ((CTCE_Cmd[c]==7))
-#define IS_CTCE_CCW_NOP(c)      ((CTCE_Cmd[c]==8))
-#define IS_CTCE_CCW_SEM(c)      ((CTCE_Cmd[c]==9))
-#define IS_CTCE_CCW_SAS(c)      ((CTCE_Cmd[c]==10))
-#define IS_CTCE_CCW_SID(c)      ((CTCE_Cmd[c]==11))
-#define IS_CTCE_CCW_RCD(c)      ((CTCE_Cmd[c]==12))
-#define IS_CTCE_CCW_RDY(c)      ((CTCE_Cmd[c]<10))
-#define IS_CTCE_CCW_RDA(c)      (((CTCE_Cmd[c]&0xFB)==2)) /* Read or Read Backward */
-#define IS_CTCE_CCW_WRA(c)      (((CTCE_Cmd[c]&0xFB)==3)) /* Write or Write EOF    */
+/* In base (non-extended) mode the WEOF (WEF) */
+/* command does not exist but classifies as   */
+/* a regular WRITE command.  The WEOF-to-WRT  */
+/* mapping is performed with this macro:      */
+#define CTCE_CMD(c)             (pDEVBLK->ctcxmode == 1 ?   (CTCE_command[c]) : \
+                                ((CTCE_command[c])==7 ? 3 : (CTCE_command[c])))
+
+#define IS_CTCE_CCW_PRE(c)      ((CTCE_command[c]==0))
+#define IS_CTCE_CCW_CTL(c)      ((CTCE_command[c]==1))
+#define IS_CTCE_CCW_RED(c)      ((CTCE_command[c]==2))
+#define IS_CTCE_CCW_WRT(c)      ((CTCE_CMD( c) ==3))
+#define IS_CTCE_CCW_SCB(c)      ((CTCE_command[c]==4))
+#define IS_CTCE_CCW_RBK(c)      ((CTCE_command[c]==6))
+#define IS_CTCE_CCW_WEF(c)      ((CTCE_CMD( c )==7))
+#define IS_CTCE_CCW_NOP(c)      ((CTCE_command[c]==8))
+#define IS_CTCE_CCW_SEM(c)      ((CTCE_command[c]==9))
+#define IS_CTCE_CCW_SBM(c)      ((CTCE_command[c]==15))
+#define IS_CTCE_CCW_SAS(c)      ((CTCE_command[c]==10))
+#define IS_CTCE_CCW_SID(c)      ((CTCE_command[c]==11))
+#define IS_CTCE_CCW_RCD(c)      ((CTCE_command[c]==12))
+#define IS_CTCE_CCW_DEP(c)      ((CTCE_CMD( c )<7))           /* Any Dependent Command */
+#define IS_CTCE_CCW_RDA(c)      (((CTCE_command[c]&0xFB)==2)) /* Read or Read Backward */
+#define IS_CTCE_CCW_WRA(c)      (((CTCE_command[c]&0xFB)==3)) /* Write or Write EOF    */
 
 /* Macros for classifying CTC states follow.  */
 /* These are numbered 0 thru 7 as per the     */
@@ -429,7 +444,7 @@ const CTCE_Fsm[16][8] = {
 
 /* inv */ { UC    , UC    , UC    , UC    , UC    , UC    , B     , B     },
 /* CB0 */ { UC    , UC    , UC    , UC    , UC    , UC    , B     , B     },
-/* SBM */ { UC    , UC    , UC    , UC    , UC    , UC    , B     , B     }
+/* SBM */ { CDS   , BA    , BA    , BA    ,ACDS   ,AUCS   , B     , B     }
 };
 
 #undef P
@@ -465,21 +480,21 @@ const CTCE_Fsm[16][8] = {
                               , IS_CTCE_MATCH(s) ? _(" MATCH") : _("") \
                               , IS_CTCE_ATTN(s)  ? _(" ATTN")  : _("")
 
-#define CTCE_X_STATE_FSM_IDX(c)                                             \
+#define CTCE_X_STATE_FSM_IDX                                                \
     ( ( ( pDEVBLK->ctcexState & 0x04 ) == 0x00 ) ? 0x06 : CTCE_STATE( pDEVBLK->ctceyState ) )
 
-#define CTCE_Y_STATE_FSM_IDX(c)                                             \
+#define CTCE_Y_STATE_FSM_IDX                                                \
     ( ( ( pDEVBLK->ctceyState & 0x04 ) == 0x00 ) ? 0x06 : CTCE_STATE( pDEVBLK->ctcexState ) )
 
 #define CTCE_NEW_X_STATE(c)                                                 \
-    ( ( CTCE_Fsm[CTCE_Cmd[c]][CTCE_X_STATE_FSM_IDX(c)].new_state != 255 ) ? \
-      ( CTCE_Fsm[CTCE_Cmd[c]][CTCE_X_STATE_FSM_IDX(c)].new_state )        : \
-      ( pDEVBLK->ctcexState & 0x07) )
+    ( ( CTCE_Fsm[CTCE_CMD( c )][CTCE_X_STATE_FSM_IDX].new_state != 255 ) ?  \
+      ( CTCE_Fsm[CTCE_CMD( c )][CTCE_X_STATE_FSM_IDX].new_state )        :  \
+      ( pDEVBLK->ctcexState & 0x07 ) )
 
 #define CTCE_NEW_Y_STATE(c)                                                 \
-    ( ( CTCE_Fsm[CTCE_Cmd[c]][CTCE_Y_STATE_FSM_IDX(c)].new_state != 255 ) ? \
-      ( CTCE_Fsm[CTCE_Cmd[c]][CTCE_Y_STATE_FSM_IDX(c)].new_state )        : \
-      ( pDEVBLK->ctceyState & 0x07) )
+    ( ( CTCE_Fsm[CTCE_CMD( c )][CTCE_Y_STATE_FSM_IDX].new_state != 255 ) ?  \
+      ( CTCE_Fsm[CTCE_CMD( c )][CTCE_Y_STATE_FSM_IDX].new_state )        :  \
+      ( pDEVBLK->ctceyState & 0x07 ) )
 
 #define CTCE_DISABLE_NAGLE
 #define CTCE_UDP
@@ -488,6 +503,47 @@ const CTCE_Fsm[16][8] = {
 /* different Hercules versions, whilst adhering to different styles.     */
 #define CTCX_DEVNUM(p)          p->devnum
 #define CTCE_FILENAME           pDEVBLK->filename + 2
+
+/**********************************************************************/
+/* This table is used by channel.c to determine if a CCW code is an   */
+/* immediate command or not                                           */
+/* The table is addressed in the DEVHND structure as 'DEVIMM immed'   */
+/* 0 : Command is NOT an immediate command                            */
+/* 1 : Command is an immediate command                                */
+/* Note : An immediate command is defined as a command which returns  */
+/* CE (channel end) during initialisation (that is, no data is        */
+/* actually transfered). In this case, IL is not indicated for a CCW  */
+/* Format 0 or for a CCW Format 1 when IL Suppression Mode is in      */
+/* effect                                                             */
+/**********************************************************************/
+
+static BYTE CTCE_immed_commands[256] =
+{
+/* 0 1 2 3 4 5 6 7 8 9 A B C D E F */
+   0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1, /* 0x */
+   0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1, /* 1x */
+   0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1, /* 2x */
+   0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1, /* 3x */
+   0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1, /* 4x */
+   0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1, /* 5x */
+   0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1, /* 6x */
+   0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1, /* 7x */
+   0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1, /* 8x */
+   0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1, /* 9x */
+   0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1, /* Ax */
+   0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1, /* Bx */
+   0,0,0,1,0,0,0,1,0,0,0,0,0,0,0,1, /* Cx */
+   0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1, /* Dx */
+   0,0,0,1,0,0,0,1,0,0,0,0,0,0,0,1, /* Ex */
+   0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1  /* Fx */
+};
+
+//  X0XX X011  No Operation
+//  MMMM M111  Control
+//  1100 0011  Set Extended Mode
+//  10XX X011  Set Basic Mode
+//  1110 0011  Prepare
+//  1XXX XX01  Write EOF (but not treated as such !)
 
 // --------------------------------------------------------------------
 // Device Handler Information Block
@@ -555,7 +611,7 @@ DEVHND ctce_device_hndinfo =
         NULL,                          /* Device Reserve             */
         NULL,                          /* Device Release             */
         NULL,                          /* Device Attention           */
-        NULL,                          /* Immediate CCW Codes        */
+        CTCE_immed_commands,           /* Immediate CCW Codes        */
         NULL,                          /* Signal Adapter Input       */
         NULL,                          /* Signal Adapter Output      */
         NULL,                          /* Hercules suspend           */
@@ -1821,22 +1877,23 @@ void  CTCE_ExecuteCCW( DEVBLK* pDEVBLK, BYTE  bCode,
     int             rc;                 // Return code
     CTCE_INFO       CTCE_Info;          // CTCE information (also for tracing)
 
-    UNREFERENCED( bFlags    );
     UNREFERENCED( bChained  );
     UNREFERENCED( bPrevCode );
     UNREFERENCED( iCCWSeq   );
     UNREFERENCED( pMore     );
 
     // Initialise our CTCE_Info and save the previous x- and y-states in it.
-    CTCE_Info.wait_rc          = 0;
-    CTCE_Info.de_ready         = 0;
-    CTCE_Info.de_ready_attn_rc = 0;
-    CTCE_Info.working_attn_rc  = 0;
-    CTCE_Info.busy_waits       = 0;
-    CTCE_Info.sent             = 0;
-    CTCE_Info.sok_buf_len      = 0;
-    CTCE_Info.state_x_prev     = pDEVBLK->ctcexState;
-    CTCE_Info.state_y_prev     = pDEVBLK->ctceyState;
+    CTCE_Info.wait_rc            = 0;
+    CTCE_Info.de_ready           = 0;
+    CTCE_Info.de_ready_attn_rc   = 0;
+    CTCE_Info.working_attn_rc    = 0;
+    CTCE_Info.busy_waits         = 0;
+    CTCE_Info.sent               = 0;
+    CTCE_Info.con_lost           = 0;
+    CTCE_Info.con_won            = 0;
+    CTCE_Info.sok_buf_len        = 0;
+    CTCE_Info.state_x_prev       = pDEVBLK->ctcexState;
+    CTCE_Info.state_y_prev       = pDEVBLK->ctceyState;
 
     // Connect to the partner CTCE device if the device file is not open
     if (pDEVBLK->fd < 0)
@@ -1909,15 +1966,17 @@ void  CTCE_ExecuteCCW( DEVBLK* pDEVBLK, BYTE  bCode,
         // at the other side and vice-versa
         parm.addr.sin_port = htons(pDEVBLK->ctce_rport + 1 );
         parm.addr.sin_addr = pDEVBLK->ctce_ipaddr;
-        rc = connect( parm.listenfd[0],
+
+        // We connect() but with a timeout value of 1000000 usec = 1 sec
+        rc = CTCE_Connect_Timeout( parm.listenfd[0],
             ( struct sockaddr * )&parm.addr,
-            sizeof( parm.addr) );
+            sizeof( parm.addr), 1000000 );
 
         // if connection was not successful, then we may retry later on when the other side becomes ready.
         if( rc < 0 )
         {
-            logmsg( _("HHCCT053I %04X CTCE: Connect error :%d -> %s:%d, %s\n"),
-                CTCX_DEVNUM( pDEVBLK ), pDEVBLK->ctce_lport, remaddr, pDEVBLK->ctce_rport + 1, strerror( HSO_errno ) );
+            logmsg( _("HHCCT053I %04X CTCE: Connect error :%d -> %s:%d, retry is possible\n"),
+                CTCX_DEVNUM( pDEVBLK ), pDEVBLK->ctce_lport, remaddr, pDEVBLK->ctce_rport + 1 );
         }
         else  // successfully connected to the other end
         {
@@ -1929,27 +1988,37 @@ void  CTCE_ExecuteCCW( DEVBLK* pDEVBLK, BYTE  bCode,
         }
     }
 
-    // Intervention required if the device file is not open
-    if( ( ( pDEVBLK->fd < 0 ) || ( pDEVBLK->ctcefd < 0 ) ) &&
-        !IS_CCW_SENSE( bCode ) &&
-        !IS_CCW_CONTROL( bCode ) )
+    // The contention winning CTCE side initially is the first one to
+    // attempt commands; each matching SCB command sent sets this as well.
+    if( ( pDEVBLK->fd < 0 ) || ( pDEVBLK->ctcefd < 0 ) )
     {
-        pDEVBLK->sense[0] = SENSE_IR;
-        *pUnitStat = CSW_CE | CSW_DE | CSW_UC;
-        return;
+        pDEVBLK->ctce_contention_loser = 0;
+
+        // Intervention required if the device file is not open
+        if( !IS_CCW_SENSE( bCode ) &&
+            !IS_CCW_CONTROL( bCode ) )
+        {
+            pDEVBLK->sense[0] = SENSE_IR;
+            *pUnitStat = CSW_CE | CSW_DE | CSW_UC;
+            return;
+        }
     }
 
     // Changes to DEVBLK are lock protected as the CTCE_RecvThread
-    // might update as well, but, due to the way actually existing
-    // software uses CTC devices, this may not be needed at all.
+    // might update as well.
     obtain_lock( &pDEVBLK->lock );
+
+    // The CCW Flags Command Chaining indicator being set indicates
+    // that a CCW Program is in progress.  The last CCW in the chain
+    // has this flag turned off.
+    pDEVBLK->ctce_ccw_flags_cc = ( ( bFlags & CCW_FLAGS_CC ) != 0 );
 
     // Copy control command byte in x command register
     pDEVBLK->ctcexCmd = bCode;
 
-    // A valid Set Extended Mode (SEM) command will have an immediate
-    // effect so that it can from then on be handled as a NOP command.
-    // Valid in this context means x-state Available and y-state
+    // A valid Set Extended / Base Mode (SEM / SBM) command will have
+    // an immediate effect so that it can from then on be handled as
+    // a NOP command.  Valid means x-state Available and y-state
     // not in Working(D) with Control, Read or Write (CRW).
     // Please note that the Basic to Extended mode switch influences
     // the CTCS FSM table indexing which is why this is done up front.
@@ -1962,16 +2031,35 @@ void  CTCE_ExecuteCCW( DEVBLK* pDEVBLK, BYTE  bCode,
         SET_CTCE_YAV( pDEVBLK->ctcexState );
     }
 
+    // Or we just set Base mode.
+    else if( IS_CTCE_CCW_SBM( pDEVBLK->ctcexCmd ) &&
+             IS_CTCE_YAV( pDEVBLK->ctcexState   ) &&
+            !IS_CTCE_CRW( pDEVBLK->ctceyState   ) )
+    {
+        pDEVBLK->ctcxmode = 0;
+    }
+
     // The new X-state and transition actions are derived from the FSM table.
     CTCE_Info.state_new   = CTCE_NEW_X_STATE( pDEVBLK->ctcexCmd );
-    CTCE_Info.actions     = CTCE_Fsm[CTCE_Cmd[pDEVBLK->ctcexCmd]][CTCE_X_STATE_FSM_IDX( pDEVBLK->ctceyState )].actions;
-    CTCE_Info.x_unit_stat = CTCE_Fsm[CTCE_Cmd[pDEVBLK->ctcexCmd]][CTCE_X_STATE_FSM_IDX( pDEVBLK->ctceyState )].x_unit_stat;
+    CTCE_Info.actions     = CTCE_Fsm[CTCE_CMD( pDEVBLK->ctcexCmd )][CTCE_X_STATE_FSM_IDX].actions;
+    CTCE_Info.x_unit_stat = CTCE_Fsm[CTCE_CMD( pDEVBLK->ctcexCmd )][CTCE_X_STATE_FSM_IDX].x_unit_stat;
 
-    *pUnitStat            = CTCE_Fsm[CTCE_Cmd[pDEVBLK->ctcexCmd]][CTCE_X_STATE_FSM_IDX( pDEVBLK->ctceyState )].x_unit_stat;
+    *pUnitStat            = CTCE_Fsm[CTCE_CMD( pDEVBLK->ctcexCmd )][CTCE_X_STATE_FSM_IDX].x_unit_stat;
+
+    // We avoid a possible command collision between a SEM command and
+    // a WRITE command already issued by the other side but not received
+    // yet.  The BUSY+ATTN response to that would cause an endless loop,
+    // which we simple avoid by replacing it with CE+DE.
+    if( IS_CTCE_CCW_SEM( pDEVBLK->ctcexCmd ) &&
+        IS_CTCE_YAV( pDEVBLK->ctcexState   ) &&
+        *pUnitStat == ( CSW_BUSY | CSW_ATTN ) )
+    {
+        *pUnitStat = CSW_CE | CSW_DE;
+    }
 
     // If a READ or READ_BACKWARD command is received whilst the WEOF
     // bit is set then the sole case for a Unit Exception applies.
-    if( IS_CTCE_WEOF( pDEVBLK->ctcexState ) &&
+    else if( IS_CTCE_WEOF( pDEVBLK->ctcexState ) &&
         IS_CTCE_CCW_RDA( pDEVBLK->ctcexCmd ) )
     {
         CLR_CTCE_WEOF( pDEVBLK->ctcexState );
@@ -1985,7 +2073,7 @@ void  CTCE_ExecuteCCW( DEVBLK* pDEVBLK, BYTE  bCode,
         CLR_CTCE_WEOF( pDEVBLK->ctcexState );
 
         // Process depending on the CCW command.
-        switch ( CTCE_Cmd[pDEVBLK->ctcexCmd] )
+        switch ( CTCE_CMD( pDEVBLK->ctcexCmd ) )
         {
 
         // Most of the CTCE commands processing (if any at all)
@@ -1998,6 +2086,7 @@ void  CTCE_ExecuteCCW( DEVBLK* pDEVBLK, BYTE  bCode,
         case CTCE_WRITE_END_OF_FILE:
         case CTCE_NO_OPERATION:
         case CTCE_SET_EXTENDED_MODE:
+        case CTCE_SET_BASIC_MODE:
             break;
 
         case CTCE_SENSE_COMMAND_BYTE:
@@ -2036,7 +2125,6 @@ void  CTCE_ExecuteCCW( DEVBLK* pDEVBLK, BYTE  bCode,
 
         // Invalid commands
         // (or never experienced / tested / supported ones)
-        case CTCE_SET_BASIC_MODE:
         case CTCE_READ_CONFIG_DATA:
         default:
 
@@ -2051,7 +2139,7 @@ void  CTCE_ExecuteCCW( DEVBLK* pDEVBLK, BYTE  bCode,
             pDEVBLK->sense[0] = SENSE_EC;
             *pUnitStat        = CSW_CE | CSW_DE | CSW_UC;
 
-        } // switch ( CTCE_Cmd( pDEVBLK->ctcexCMD ) )
+        } // switch ( CTCE_CMD( pDEVBLK->ctcexCMD ) )
 
         // In most cases we need to inform the other (y-)side so we SEND
         // our command (and data) to the other side.  During this process
@@ -2059,6 +2147,13 @@ void  CTCE_ExecuteCCW( DEVBLK* pDEVBLK, BYTE  bCode,
         if( IS_CTCE_SEND( CTCE_Info.actions ) )
         {
             CTCE_Send( pDEVBLK, sCount, pIOBuf, pUnitStat, pResidual, &CTCE_Info );
+
+            // In case we sent a matching SCB command, this side becomes
+            // the contention winner side; the receiver updates accordingly.
+            if( IS_CTCE_CCW_SCB( pDEVBLK->ctcexCmd ) && CTCE_Info.sent )
+            {
+                pDEVBLK->ctce_contention_loser = 0;
+            }
         }
 
         // This (x-)side will leave the Not Ready state.
@@ -2341,6 +2436,12 @@ static int  CTCE_Init( DEVBLK *dev, int argc, char *argv[] )
     initialize_lock( &dev->ctceEventLock );
     initialize_condition( &dev->ctceEvent );
 
+    // The ctce_contention_loser side of a CTCE connection will act as
+    // if a colliding dependent command arrived following the one at
+    // the other side.  The CTC side connecting 1st will reset this,
+    // and matching SCB commands may alter it also.
+    dev->ctce_contention_loser = 1;
+
     return 0;
 }
 
@@ -2503,6 +2604,10 @@ static void   CTCE_Send( DEVBLK* pDEVBLK,   U16        sCount,
 
         pDEVBLK->sense[0] = SENSE_EC;
         *pUnitStat        = CSW_CE | CSW_DE | CSW_UC;
+
+        // For lack of anything better, we return to the not ready state.
+        CLR_CTCE_ALLF(pDEVBLK->ctcexState);
+        SET_CTCE_YNR(pDEVBLK->ctcexState);
         return;
     }
 
@@ -2539,12 +2644,6 @@ static void   CTCE_Send( DEVBLK* pDEVBLK,   U16        sCount,
         obtain_lock( &pDEVBLK->lock );
         release_lock( &pDEVBLK->ctceEventLock );
 
-        // Trace the non-zero WAIT RC (e.g. timeout, RC=138 (windows) or 110 (unix)).
-        if( pCTCE_Info->wait_rc != 0 )
-        {
-            CTCE_Trace( pDEVBLK, sCount, CTCE_SND, pCTCE_Info, pDEVBLK->buf, pUnitStat );
-        }
-
         // First we check for Halt or Clear Subchannel
         if( pCTCE_Info->wait_rc == ETIMEDOUT || pCTCE_Info->wait_rc == EINTR )
         {
@@ -2564,12 +2663,26 @@ static void   CTCE_Send( DEVBLK* pDEVBLK,   U16        sCount,
             }
 
             // Other timeouts or errors should not occur.
+            // But if they do, we try to recover as if the other side
+            // was in a working(D) state.
             else
             {
-                *pUnitStat = CSW_CE | CSW_DE | CSW_UC | CSW_SM;
-                pDEVBLK->sense[0] = 0;
+                *pUnitStat = CSW_BUSY | CSW_ATTN ;
+                SET_CTCE_YAV( pDEVBLK->ctcexState );
+            }
+
+            // Produce a trace logging if requested.
+            if( pDEVBLK->ccwtrace || pDEVBLK->ccwstep )
+            {
+                CTCE_Trace( pDEVBLK, sCount, CTCE_SND, pCTCE_Info, pDEVBLK->buf, pUnitStat );
             }
             return;
+        }
+
+        // Trace the non-zero WAIT RC (e.g. timeout, RC=138 (windows) or 110 (unix)).
+        else if( pCTCE_Info->wait_rc != 0 )
+        {
+            CTCE_Trace( pDEVBLK, sCount, CTCE_SND, pCTCE_Info, pDEVBLK->buf, pUnitStat );
         }
 
         // A WRITE EOF command from the other side will have resulted
@@ -2597,10 +2710,23 @@ static void   CTCE_Send( DEVBLK* pDEVBLK,   U16        sCount,
         pDEVBLK->ctce_UnitStat = CSW_CE | CSW_DE;
     }
 
+    // If the command (by now matched) was a CONTROL command, then this
+    // side become the contention loser.
+    if( IS_CTCE_CCW_CTL( pDEVBLK->ctcexCmd ) )
+    {
+        pDEVBLK->ctce_contention_loser = 1;
+    }
+
+    // Command collisions never return data.
+    if( pDEVBLK->ctce_UnitStat == (CSW_BUSY | CSW_ATTN) )
+    {
+        *pResidual = sCount;
+    }
+
     // If the command (by now matched) was a READ command, then the
     // other (y-)side data is available in the DEVBLK buf, so we
     // can copy it into the IO channel buffer and compute residual.
-    if( IS_CTCE_CCW_RED( pDEVBLK->ctcexCmd ) )
+    else if( IS_CTCE_CCW_RED( pDEVBLK->ctcexCmd ) )
     {
 
         // The actual length of data transferred is the minimum of
@@ -2642,7 +2768,7 @@ static void*  CTCE_RecvThread( void* argp )
     BYTE          *buf;                          //-> Device recv data buffer
     U64            ctcePktCnt = 0;               // Recvd Packet Count
     U64            ctceBytCnt = 0;               // Recvd Byte Count
-    BYTE           ctce_dev_attn_UnitStat;       // Parameter for device_attention
+    BYTE           ctce_recv_mods_UnitStat;      // UnitStat modifications
     int            i = 0;                        // temporary variable
 
     // When the receiver thread is (re-)started, the CTCE devblk is (re-)initialized
@@ -2661,9 +2787,9 @@ static void*  CTCE_RecvThread( void* argp )
     pSokBuf = (CTCE_SOKPFX*)buf;
 
     // Initialise our CTCE_Info as needed.
-    CTCE_Info.de_ready_attn_rc = 0;
-    CTCE_Info.working_attn_rc  = 0;
-    CTCE_Info.busy_waits       = 0;
+    CTCE_Info.de_ready_attn_rc   = 0;
+    CTCE_Info.working_attn_rc    = 0;
+    CTCE_Info.busy_waits         = 0;
 
     // This thread will loop until we receive a zero-length packet caused by CTCX_close from the other side.
     for( ; ; )
@@ -2719,8 +2845,8 @@ static void*  CTCE_RecvThread( void* argp )
             ctcePktCnt += 1 ;
             ctceBytCnt += iLength ;
 
-            // Initialise the device_attention parameter.
-            ctce_dev_attn_UnitStat = 0;
+            // Initialise the UnitStat modifications.
+            ctce_recv_mods_UnitStat = 0;
 
             // Save the previous CTCE states,
             // our (x-)side as well as the other (y-)side.
@@ -2737,170 +2863,244 @@ static void*  CTCE_RecvThread( void* argp )
             // state transition on our (x-)side, as well as some actions.
             // Both depend on our current (x-)side state and are encoded
             // within the FSM table.
-            CTCE_Info.actions = CTCE_Fsm[CTCE_Cmd[pSokBuf->CmdReg]]
-                [CTCE_STATE( pDEVBLK->ctcexState )].actions;
             CTCE_Info.state_new = CTCE_NEW_Y_STATE( pSokBuf->CmdReg );
+            CTCE_Info.actions     = CTCE_Fsm[CTCE_CMD( pSokBuf->CmdReg )]
+                                            [CTCE_Y_STATE_FSM_IDX].actions;
+            CTCE_Info.x_unit_stat = CTCE_Fsm[CTCE_CMD( pSokBuf->CmdReg )]
+                                            [CTCE_Y_STATE_FSM_IDX].x_unit_stat;
+            CTCE_Info.con_lost = 0;
+            CTCE_Info.con_won = 0;
 
-            // Device-End status indicating ready will be presented
-            // if the y-side has just now become ready.
-            CTCE_Info.de_ready = ( IS_CTCE_YNR( pDEVBLK->ctceyState ) &&
-                                  !IS_CTCE_YNR( pSokBuf->FsmSta ) ) ? 1 : 0;
-
-            pDEVBLK->ctceyState = pSokBuf->FsmSta;
-            pDEVBLK->ctceyCmd =  pSokBuf->CmdReg;
-            pDEVBLK->ctceyCmdSCB = pSokBuf->CmdReg;
-
-            // Only if the other (y-)side sent us a write command will
-            // we copy the socket buffer into the device buffer.
-            if( IS_CTCE_CCW_WRT( pDEVBLK->ctceyCmd ) )
+            // Command collision occurs when both sides receive a
+            // (non-matching) DEPendent command at the same time,
+            // crossing each other in xfer to the other side (e.g. two
+            // READ or WRITE commands).  Both sides would respond with
+            // a Busy+Attention device status.
+            if( ( CTCE_Info.x_unit_stat == ( CSW_BUSY | CSW_ATTN ) )
+                && IS_CTCE_CCW_DEP(  pSokBuf->CmdReg ) )
             {
 
-                // We retain the sCount of this WRITE command for later
-                // comparison against the matching READ command, ahead
-                // of the data itself following CTCE_SOKPFX.
-                *(U16*)( pDEVBLK->buf + sizeof(CTCE_SOKPFX) ) = pSokBuf->sCount ;
-
-                memcpy( pDEVBLK->buf + sizeof(CTCE_SOKPFX) + sizeof(pSokBuf->sCount) ,
-                    buf + sizeof(CTCE_SOKPFX), pSokBuf->sCount );
-            }
-
-            // If the other side sent us a WRITE EOF command
-            // then we just set the WEOF flag on our side.
-            else if( IS_CTCE_CCW_WEF( pDEVBLK->ctceyCmd ) )
-            {
-                SET_CTCE_WEOF( pDEVBLK->ctcexState );
-            }
-
-            // If the other side sent us a READ or READBK command whilst the
-            // previous command at our (x-) side was a WRITE EOF command then
-            // the other side will have generated a Unit Exception to the WEOF
-            // setting, effectively discarding that READ command.  We therefore
-            // ignore this READ command, but we need to set the resulting
-            // state to Available.  We clear the Wait + Attention actions.
-            else if( IS_CTCE_CCW_RDA( pDEVBLK->ctceyCmd ) &&
-                     IS_CTCE_CCW_WEF( pDEVBLK->ctcexCmd ) &&
-                     IS_CTCE_ATTN( CTCE_Info.actions ) )
-            {
-                SET_CTCE_YAV( pDEVBLK->ctceyState );
-                CLR_CTCE_WAIT( CTCE_Info.actions );
-                CLR_CTCE_ATTN( CTCE_Info.actions );
-            }
-
-            // If the other (y-)side sent us a matching command for our
-            // (x-)side Working(D) state, then we need to signal that
-            // condition so that CTCE_Send no longer needs to wait.
-            if( IS_CTCE_MATCH( CTCE_Info.actions ) )
-            {
-                obtain_lock( &pDEVBLK->ctceEventLock );
-                signal_condition( &pDEVBLK->ctceEvent );
-                release_lock( &pDEVBLK->ctceEventLock );
-
-                // Both side return to the available state.
-                SET_CTCE_YAV( pDEVBLK->ctcexState );
-                SET_CTCE_YAV( pDEVBLK->ctceyState );
-
-                // All matching commands result in a final UnitStat
-                // CE + DE stat at the local device end, with one
-                // exception: when the matching is for a write command
-                // in BASE mode only, then a zero UnitStat is needed.
-                // This latter condition may be caused by us waiting
-                // for the matching READ to arrive wihtout generating
-                // an initial UnitStat=0 response; but the condition
-                // only applies to base mode (e.g. MVS GRS).
-                if( ( pDEVBLK->ctcxmode == 1 ) ||
-                   !( IS_CTCE_CCW_RDA( pDEVBLK->ctceyCmd ) ) )
+                // In a real CTC this never occurs, there is always a
+                // first and a second side.  CTCE emulates the second
+                // side behaviour where ctce_contention_loser==1.
+                if( pDEVBLK->ctce_contention_loser )
                 {
-                    pDEVBLK->ctce_UnitStat |= CSW_CE | CSW_DE;
-                }
-            } // if( IS_CTCE_MATCH( CTCE_Info.actions ) )
 
-            // If the other (y-)side sent us a Device-End status
-            // indicating Ready then this has to be presented on this side.
-            else if( CTCE_Info.de_ready )
-            {
-                release_lock( &pDEVBLK->lock );
-                ctce_dev_attn_UnitStat |= CSW_DE;
-                CTCE_Info.de_ready_attn_rc = device_attention( pDEVBLK, CSW_DE );
-                obtain_lock( &pDEVBLK->lock );
+                    // This is done by signaling this by now awaiting
+                    // side as if a matching command was received, but
+                    // only after re-instating the original FSM state
+                    // and ensuring that the required Busy+Attention
+                    // device status will bereturned.  Effectively,
+                    // this is a contention lost situation.
+                    CTCE_Info.con_lost = 1;
+                    pDEVBLK->ctcexState = CTCE_Info.state_new;
+                    pDEVBLK->ctce_UnitStat = CSW_BUSY | CSW_ATTN;
+                    obtain_lock( &pDEVBLK->ctceEventLock );
+                    signal_condition( &pDEVBLK->ctceEvent );
+                    release_lock( &pDEVBLK->ctceEventLock );
 
-                // Reset sense byte 0 bits 1 and 7.
-                pDEVBLK->sense[0] &= ~( SENSE_IR | SENSE_OC );
-            }
-
-            // If the other (y-)side sent us a command that may require
-            // us to signal attention then we will do so provided no
-            // program chain is in progress (SA22-7203-00, item 2.1.1,
-            // second paragraph).  Ignoring this would yield RC=1,
-            // which indicates a busy or status pending condition.
-
-            if( ( IS_CTCE_ATTN( CTCE_Info.actions ) ) &&
-                ( !pDEVBLK->busy || ( pDEVBLK->ctcxmode == 0 ) ) )
-            {
-
-                // Only for basic mode CTC's (e.g. MVS GRS) do we need
-                // to ensure that CTCE_Send receives any matching CCW
-                // command signal and finishes the CCW in progress
-                // before we now signal ATTN.  An easy but not so
-                // elegant method is a short wait until this side
-                // is no longer busy or in pending status.  We wait
-                // for up to 10 seconds (busy_waits==20), but have
-                // only (once) experienced 10 msec (busy_waits=10).
-                // This process is necessary, but only very seldom so.
-                if( pDEVBLK->ctcxmode == 0 )
-                {
-                    i = 10;
-                    for( CTCE_Info.busy_waits = 0;
-                         ( pDEVBLK->ctcxmode == 0    ) &&
-                         ( CTCE_Info.busy_waits < 20 ) &&
-                         ( pDEVBLK->busy        ||
-                           pDEVBLK->pending     ||
-                           pDEVBLK->pcipending  ||
-                           pDEVBLK->attnpending ||
-                           pDEVBLK->scsw.flag3 & SCSW3_SC_PEND );
-                         CTCE_Info.busy_waits++ )
-                    {
-                        release_lock( &pDEVBLK->lock );
-                        usleep(i);
-                        i = i * 2;
-                        obtain_lock( &pDEVBLK->lock );
-                    }
+                    // After our (x-)state is reset, we need to
+                    // re-compute the FSM state transition effects.
+                    CTCE_Info.state_new = CTCE_NEW_Y_STATE( pSokBuf->CmdReg );
+                    CTCE_Info.actions = CTCE_Fsm[CTCE_CMD( pSokBuf->CmdReg )]
+                                                [CTCE_Y_STATE_FSM_IDX].actions;
                 }
 
-                // The release and re-obtain lock is only needed
-                // because device_attention also obtains and releases
-                // the lock, which under Unix causes HHCCP017I eventually.
-                release_lock( &pDEVBLK->lock );
-                ctce_dev_attn_UnitStat |= CSW_ATTN;
-                CTCE_Info.working_attn_rc = device_attention( pDEVBLK, CSW_ATTN );
-                obtain_lock( &pDEVBLK->lock );
+                // At the contention winning side, we can simply ignore
+                // the CTCE_Recv, as the losing side will effectively
+                // behave is if it never happened.
+                else
+                {
+                    CTCE_Info.con_won = 1;
+                }
+            }
+            if( CTCE_Info.con_won != 1 )
+            {
 
-                // WAIT ATTN Non-zero RC will be reported but only if
-                // RC=1 remains after a limited number of retries.
-                // (This was only experienced during MVS GRS CCW
-                // programs, never duing XCF CCW programs, but has not
-                // been experienced anymore since the introduction of
-                // the busy_waits process directly above.)
-                for( i = 0; ( CTCE_Info.working_attn_rc == 1 ) && ( i < 10 ); i++ )
+                // Device-End status indicating ready will be presented
+                // if the y-side has just now become ready.
+                CTCE_Info.de_ready = ( IS_CTCE_YNR( pDEVBLK->ctceyState ) &&
+                                      !IS_CTCE_YNR( pSokBuf->FsmSta ) ) ? 1 : 0;
+
+                // Our (x-)side knowledge from the other (y-)side is updated.
+                pDEVBLK->ctceyState = pSokBuf->FsmSta;
+                pDEVBLK->ctceyCmd =  pSokBuf->CmdReg;
+                pDEVBLK->ctceyCmdSCB = pSokBuf->CmdReg;
+
+                // Only if the other (y-)side sent us a write command will
+                // we copy the socket buffer into the device buffer.
+                if( IS_CTCE_CCW_WRT( pDEVBLK->ctceyCmd ) )
+                {
+
+                    // We retain the sCount of this WRITE command for later
+                    // comparison against the matching READ command, ahead
+                    // of the data itself following CTCE_SOKPFX.
+                    *(U16*)( pDEVBLK->buf + sizeof(CTCE_SOKPFX) ) = pSokBuf->sCount ;
+
+                    memcpy( pDEVBLK->buf + sizeof(CTCE_SOKPFX) + sizeof(pSokBuf->sCount) ,
+                        buf + sizeof(CTCE_SOKPFX), pSokBuf->sCount );
+                }
+
+                // If the other side sent us a WRITE EOF command
+                // then we just set the WEOF flag on our side.
+                else if( IS_CTCE_CCW_WEF( pDEVBLK->ctceyCmd ) )
+                {
+                    SET_CTCE_WEOF( pDEVBLK->ctcexState );
+                }
+
+                // If the other side sent us a READ or READBK command whilst the
+                // previous command at our (x-) side was a WRITE EOF command then
+                // the other side will have generated a Unit Exception to the WEOF
+                // setting, effectively discarding that READ command.  We therefore
+                // ignore this READ command, but we need to set the resulting
+                // state to Available.  We clear the Wait + Attention actions.
+                else if( IS_CTCE_CCW_RDA( pDEVBLK->ctceyCmd ) &&
+                         IS_CTCE_CCW_WEF( pDEVBLK->ctcexCmd ) &&
+                         IS_CTCE_ATTN( CTCE_Info.actions ) )
+                {
+                    SET_CTCE_YAV( pDEVBLK->ctceyState );
+                    CLR_CTCE_WAIT( CTCE_Info.actions );
+                    CLR_CTCE_ATTN( CTCE_Info.actions );
+                }
+
+                // If the other (y-)side sent us a matching command for our
+                // (x-)side Working(D) state, then we need to signal that
+                // condition so that CTCE_Send no longer needs to wait.
+                if( IS_CTCE_MATCH( CTCE_Info.actions ) )
+                {
+                    obtain_lock( &pDEVBLK->ctceEventLock );
+                    signal_condition( &pDEVBLK->ctceEvent );
+                    release_lock( &pDEVBLK->ctceEventLock );
+
+                    // Both sides return to the available state.
+                    SET_CTCE_YAV( pDEVBLK->ctcexState );
+                    SET_CTCE_YAV( pDEVBLK->ctceyState );
+
+                    // All matching commands result in a final UnitStat
+                    // CE + DE stat at the local device end.
+                    ctce_recv_mods_UnitStat = CSW_CE | CSW_DE;
+                } // if( IS_CTCE_MATCH( CTCE_Info.actions ) )
+
+                // If the other (y-)side sent us a Device-End status
+                // indicating Ready then this has to be presented on this side.
+                else if( CTCE_Info.de_ready )
                 {
                     release_lock( &pDEVBLK->lock );
-                    usleep(1000);
-                    CTCE_Info.working_attn_rc = device_attention( pDEVBLK, CSW_ATTN );
+                    ctce_recv_mods_UnitStat = CSW_DE;
+                    CTCE_Info.de_ready_attn_rc = device_attention( pDEVBLK, CSW_DE );
                     obtain_lock( &pDEVBLK->lock );
-                }
-                CTCE_Info.working_attn_retry = i;
-            } // if( IS_CTCE_ATTN( CTCE_Info.actions ) ...
 
-            // Merge any device_attention UnitStat into the final one.
-            pDEVBLK->ctce_UnitStat |= ctce_dev_attn_UnitStat;
+                    // Reset sense byte 0 bits 1 and 7.
+                    pDEVBLK->sense[0] &= ~( SENSE_IR | SENSE_OC );
+
+                }
+
+                // If the other (y-)side sent us a command that may require
+                // us to signal attention then we will do so provided no
+                // program chain is in progress (SA22-7203-00, item 2.1.1,
+                // second paragraph).  We test for that condition using the
+                // Command Chaining flag on the last received CCW.
+                CTCE_Info.attn_can = 0;
+                if( IS_CTCE_ATTN( CTCE_Info.actions )
+                    && ( !pDEVBLK->ctce_ccw_flags_cc )
+                    && ( CTCE_Info.con_lost == 0 ) )
+                {
+
+                    // Produce a CTCE Trace logging if requested.
+                    if( pDEVBLK->ccwtrace || pDEVBLK->ccwstep )
+                    {
+
+                        // Disable ATTN RC reporting this time.
+                        CTCE_Info.working_attn_rc = -1;
+
+                        // In a contention winner situation, the command
+                        // received from the other (y-)side still needs
+                        // to be reported correctly.
+                        pDEVBLK->ctceyCmd =  pSokBuf->CmdReg;
+                        CTCE_Info.sok_buf_len = iLength;
+                        CTCE_Trace( pDEVBLK, pSokBuf->sCount, CTCE_RCV, &CTCE_Info, buf, &ctce_recv_mods_UnitStat );
+                    }
+
+                    // The device_attention might not work on the first
+                    // attempt due to the fact that we need to release
+                    // the device lock around it, merely because that
+                    // routine obtains and releases the device lock.
+                    // During that short period, one or more commands
+                    // may have come in between, causing a device busy
+                    // and a possible other (y-)side status update. So
+                    // we may need to re-try the ATTN if needed at all.
+                    release_lock( &pDEVBLK->lock );
+                    CTCE_Info.working_attn_rc = 1;
+                    for( CTCE_Info.busy_waits = 0;
+                         ( CTCE_Info.working_attn_rc == 1 ) &&
+                         ( CTCE_Info.attn_can == 0 ) &&
+                         ( CTCE_Info.busy_waits <= 20 ) ;
+                         CTCE_Info.busy_waits++ )
+                    {
+                        CTCE_Info.working_attn_rc = device_attention( pDEVBLK, CSW_ATTN );
+
+                        // ATTN RC=1 means a device busy status did
+                        // appear so that the signal did not work.
+                        // We will retry after some (increasingly)
+                        // small amount of time.
+                        if( CTCE_Info.working_attn_rc == 1 )
+                        {
+                            if( CTCE_Info.busy_waits == 0 )
+                            {
+                                i = 10;
+                            }
+                            else
+                            {
+                                i = i * 2;
+                            }
+                            usleep(i);
+
+                            // Cancel the ATTN in case a CCW program
+                            // has started in the mean time.
+                            if ( pDEVBLK->ctce_ccw_flags_cc )
+                            {
+                                CTCE_Info.attn_can = 1;
+                            }
+                        }
+                    }
+                    obtain_lock( &pDEVBLK->lock );
+
+                    // We will show the ATTN status if it was signalled.
+                    if( CTCE_Info.working_attn_rc == 0 )
+                    {
+                        ctce_recv_mods_UnitStat = CSW_ATTN;
+                    }
+                    CTCE_Info.busy_waits -= 1;
+                } // if( IS_CTCE_ATTN( CTCE_Info.actions ) && ... /* Attention Needed */
+                else if( IS_CTCE_ATTN( CTCE_Info.actions ) )
+                {
+                    CTCE_Info.busy_waits = 0;
+                    CTCE_Info.attn_can = 1;
+                }
+            }
+
+            // Merge any UnitStat modifications into the final one.
+            pDEVBLK->ctce_UnitStat |= ctce_recv_mods_UnitStat;
 
             // Produce a CTCE Trace logging if requested.
             if( pDEVBLK->ccwtrace || pDEVBLK->ccwstep
+                || ( ctce_recv_mods_UnitStat == ( CSW_BUSY | CSW_ATTN ) )
                 || ( CTCE_Info.de_ready_attn_rc != 0 )
-                || ( CTCE_Info.working_attn_rc  != 0 )
+                || ( ( CTCE_Info.working_attn_rc  != 0 ) && ( CTCE_Info.attn_can == 0 ) )
                 || ( CTCE_Info.busy_waits       >= 3 ) )
             {
+
+                // In a contention winner situation, the command
+                // received from the other (y-)side still needs
+                // to be reported correctly.
+                pDEVBLK->ctceyCmd =  pSokBuf->CmdReg;
+
+                if( ctce_recv_mods_UnitStat != 0 )
+                {
+                    ctce_recv_mods_UnitStat = pDEVBLK->ctce_UnitStat;
+                }
                 CTCE_Info.sok_buf_len = iLength;
-                CTCE_Trace( pDEVBLK, pSokBuf->sCount, CTCE_RCV, &CTCE_Info, buf, &pDEVBLK->ctce_UnitStat );
+                CTCE_Trace( pDEVBLK, pSokBuf->sCount, CTCE_RCV, &CTCE_Info, buf, &ctce_recv_mods_UnitStat );
             }
             CTCE_Info.de_ready_attn_rc = 0;
             CTCE_Info.working_attn_rc  = 0;
@@ -3110,23 +3310,23 @@ void            CTCE_Trace( const DEVBLK*             pDEVBLK,
     BYTE           ctce_state_verify;          // CTCE state to be verfified
     char           ctce_state_l_xy[2];         // CTCE X+Y states, left
     char           ctce_state_r_xy[2];         // CTCE X+Y stares, right
-    char           ctce_trace_stat[16];        // to contain " Stat=.."
+    char           ctce_trace_stat[16];        // to contain " Stat=.. CC=."
     char           ctce_trace_xtra[256];       // to contain extra info when tracing
     char           ctce_trace_xtra_temp[256];  // temporary work area for the above
 
     pSokBuf = (CTCE_SOKPFX*)pCTCE_Buf;
 
-    // Report on the device status.
+    // Report on the device status and CCW Command Chaining flag.
     if( ( eCTCE_Cmd_Xfr != CTCE_RCV ) || ( *pUnitStat != 0 ) ||
         ( IS_CTCE_MATCH( pCTCE_Info->actions ) ) )
     {
         snprintf( ctce_trace_stat, sizeof( ctce_trace_stat ),
-            "Stat=%02X", *pUnitStat );
+            "Stat=%02X CC=%d", *pUnitStat, pDEVBLK->ctce_ccw_flags_cc );
     }
     else
     {
         snprintf( ctce_trace_stat, sizeof( ctce_trace_stat ),
-            "       " );
+            "        CC=%d", pDEVBLK->ctce_ccw_flags_cc );
     }
 
     ctce_trace_xtra[0] = '\0' ;
@@ -3137,21 +3337,15 @@ void            CTCE_Trace( const DEVBLK*             pDEVBLK,
     // that case will show "ATTN" at the rightmost end.
     if( IS_CTCE_ATTN( pCTCE_Info->actions ) && ( eCTCE_Cmd_Xfr == CTCE_RCV ) )
     {
-        if( pDEVBLK->busy && ( pDEVBLK->ctcxmode == 1 ) )
+        if( pCTCE_Info->attn_can )
         {
             strlcat( ctce_trace_xtra, "->NONE", sizeof( ctce_trace_xtra ) );
         }
-        else
+        else if( pCTCE_Info->working_attn_rc > -1 )
         {
             snprintf( ctce_trace_xtra_temp, sizeof( ctce_trace_xtra_temp ),
                 "->RC=%d", pCTCE_Info->working_attn_rc );
             strlcat( ctce_trace_xtra, ctce_trace_xtra_temp, sizeof( ctce_trace_xtra ) );
-            if( pCTCE_Info->working_attn_retry > 0 )
-            {
-                snprintf( ctce_trace_xtra_temp, sizeof( ctce_trace_xtra_temp ),
-                    "(retry=%d)", pCTCE_Info->working_attn_retry );
-                strlcat( ctce_trace_xtra, ctce_trace_xtra_temp, sizeof( ctce_trace_xtra ) );
-            }
         }
     }
 
@@ -3244,7 +3438,7 @@ void            CTCE_Trace( const DEVBLK*             pDEVBLK,
         if( IS_CTCE_CCW_SCB( ctce_Cmd ) )
         {
             snprintf( ctce_trace_xtra_temp, sizeof( ctce_trace_xtra_temp ),
-                " SCB=%02X=%s", pCTCE_Info->scb, CTCE_CmdStr[CTCE_Cmd[pCTCE_Info->scb]] );
+                " SCB=%02X=%s", pCTCE_Info->scb, CTCE_CmdStr[CTCE_CMD( pCTCE_Info->scb )] );
             strlcat( ctce_trace_xtra, ctce_trace_xtra_temp, sizeof( ctce_trace_xtra ) );
         }
     }
@@ -3293,6 +3487,18 @@ void            CTCE_Trace( const DEVBLK*             pDEVBLK,
         strlcat( ctce_trace_xtra, ctce_trace_xtra_temp, sizeof( ctce_trace_xtra ) );
     }
 
+    // Report a contention loser situation.
+    if( pCTCE_Info->con_lost )
+    {
+        strlcat( ctce_trace_xtra, " CON_LOSER", sizeof( ctce_trace_xtra ) );
+    }
+
+    // Report a contention winner situation.
+    if( pCTCE_Info->con_won )
+    {
+        strlcat( ctce_trace_xtra, " CON_WINNER", sizeof( ctce_trace_xtra ) );
+    }
+
 /*
 
 HHCCT079I <src_dev> CTCE: <direction> <dst_dev> <seq#> cmd=<cmd>=<cmd_hex>
@@ -3325,7 +3531,7 @@ Action
     logmsg( _("HHCCT079I %04X CTCE: %s %.4s #%04X cmd=%s=%02X xy=%.2s%s%.2s l=%04X k=%08X %s%s%s%s%s%s\n"),
         CTCX_DEVNUM( pDEVBLK ), CTCE_XfrStr[eCTCE_Cmd_Xfr],
         CTCE_FILENAME, ctce_PktSeq,
-        CTCE_CmdStr[CTCE_Cmd[ctce_Cmd]], ctce_Cmd,
+        CTCE_CmdStr[CTCE_CMD( ctce_Cmd )], ctce_Cmd,
         ctce_state_l_xy, CTCE_XfrStr[eCTCE_Cmd_Xfr],
         ctce_state_r_xy,
         sCount, IS_CTCE_CCW_WRT( ctce_Cmd )
@@ -3339,3 +3545,53 @@ Action
     return;
 }
 
+// ---------------------------------------------------------------------
+// CTCE_connect_timeout
+// ---------------------------------------------------------------------
+//
+// connect but with a timeout parameter.
+//
+
+int CTCE_Connect_Timeout(int                    sockfd,
+                         const struct sockaddr* saptr,
+                         const socklen_t        salen,
+                         const int              usec)
+{
+    int                   rc;                    // connect return code
+    fd_set                read_set, write_set;   // socket sets for select
+    static struct timeval connect_timeout;       // max connect wait time
+
+    // Switch to non-blocking mode during the next connect.
+    socket_set_blocking_mode( sockfd, 0 ) ;
+    rc = connect( sockfd, saptr, salen );
+
+    // In case connect() did not complete immediately then we prepare
+    // the select() to wait for the specified amount of time.
+    if( rc < 0 )
+    {
+        FD_ZERO ( &read_set );
+        FD_SET( sockfd, &read_set );
+        write_set = read_set ;
+        connect_timeout.tv_sec = 0;
+        connect_timeout.tv_usec = usec;
+
+        // Then we issue select() until it returns a real error.
+        // A zero return code means the select() timed out,
+        // a positive one signifies the connect() took place.
+        do
+        {
+            rc = select( sockfd + 1, &read_set, &write_set, NULL,
+          		   usec ? &connect_timeout : NULL );
+        } while( (rc < 0) && ( HSO_errno == HSO_EINTR ) );
+
+        if( rc == 0 )
+        {
+            close_socket( sockfd ) ;
+            rc = -1;
+        }
+    }
+
+    // Switch back to original non-blocking mode and return
+    socket_set_blocking_mode( sockfd, 1 ) ;
+    return rc;
+}

--- a/dasdtab.c
+++ b/dasdtab.c
@@ -445,8 +445,7 @@ BYTE buf[256];
                         dev->ckdtab->devt, dev->ckdtab->model);
     for (i = 4; i < 30; i++)
         buf[i] = host_to_guest(buf[i]);
-    buf[30] = 0x00;
-    buf[31] = (dev->devnum & 0xFF);
+    store_hw(buf + 30, dev->devnum);        /* Uniquely tag within system */
 
     /* Bytes 32-63: NED 2  Node element descriptor for the string */
     store_fw (buf + 32, 0xc4000000);

--- a/dat.h
+++ b/dat.h
@@ -1852,7 +1852,22 @@ RADR ptemask;
     {
         INVALIDATE_AIA(regs->guestregs);
         for (i = 0; i < TLBN; i++)
-            if ((regs->guestregs->tlb.TLB_PTE(i) & ptemask) == pte)
+/************************************************************************** @PJJ */
+/* The guest registers in the SIE copy TLB PTE entries for DAT-OFF guests * @PJJ */
+/* like CMS do NOT actually contain the PTE (but rather the host primary  * @PJJ */
+/* virtual address, both masked with TBLID_PAGEMASK).  In order to check  * @PJJ */
+/* if such guest TLB entry needs to be cleared, one needs to check the    * @PJJ */
+/* parallel host registers TLB PTE entry.  Hence that the if-test that    * @PJJ */
+/* follows needed to be expanded.  Originally it was just :               * @PJJ */
+/*                                                                        * @PJJ */
+/*          if ((regs->guestregs->tlb.TLB_PTE(i) & ptemask) == pte)       * @PJJ */
+/*                                                                        * @PJJ */
+/* and it is now expanded with the additional test as follows :           * @PJJ */
+/*                                                                        * @PJJ */
+/*                                        (Peter J. Jansen, 26-Jul-2016)  * @PJJ */
+/************************************************************************** @PJJ */
+            if ((regs->guestregs->tlb.TLB_PTE(i) & ptemask) == pte ||    /* @PJJ */
+                 (regs->hostregs->tlb.TLB_PTE(i) & ptemask) == pte)      /* @PJJ */
                 regs->guestregs->tlb.TLB_VADDR(i) &= TLBID_PAGEMASK;
     }
     else

--- a/hstructs.h
+++ b/hstructs.h
@@ -1011,7 +1011,7 @@ struct DEVBLK {                         /* Device configuration block*/
         int     ctcrem;                 /* bytes remaining in buffer */
         int     ctclastpos;             /* last packet read          */
         int     ctclastrem;             /* last packet read          */
-        u_int   ctcxmode:1;             /* 0=Basic mode, 1=Extended  */
+        u_int   ctcxmode:1;             /* 1=Extended, 0=Basic mode  */
         BYTE    ctctype;                /* CTC_xxx device type       */
         BYTE    netdevname[IFNAMSIZ];   /* network device name       */
 
@@ -1033,6 +1033,8 @@ struct DEVBLK {                         /* Device configuration block*/
         int     ctce_lport;             /* CTCE Local  port #   @PJJ */
         int     ctce_rport;             /* CTCE Remote port #   @PJJ */
         struct in_addr ctce_ipaddr;     /* CTCE Dest IP addr    @PJJ */
+        u_int   ctce_contention_loser:1;/* CTCE cmd collision   @PJJ */
+        u_int   ctce_ccw_flags_cc:1;    /* CTCE ccw in progres  @PJJ */
 
         /*  Device dependent fields for printer                      */
 


### PR DESCRIPTION
Roger,

Following more in-depth testing CTCE device functionality against the CTC Adapter specifications, it became clear that a number of fixes were needed.  The code was also simplified and is now more stable than before. Also the CTCE connect() timeout has been reduced to 1 second.

The EQID computation for DASD with CCUU addresses with identical UU part was wrong and is now fixed.

Another fix is the correction to the IPTE instruction in "dat.h", which was observed to NEVER invalidate guestregs TLB entries when under SIE in DAT-OFF mode. This caused intermittent problems.  This fix was subsequently extended by a more encompassing commit by Iwan Warren.  

Best regards,

Peter