### PR TITLE
Enable support for MS VS2017

### DIFF
--- a/decimal.c
+++ b/decimal.c
@@ -1147,7 +1147,7 @@ int     carry;                          /* Carry indicator           */
 } /* end DEF_INST(multiply_decimal) */
 
 
-#if defined(_MSVC_) && (_MSC_VER == 1900)
+#if defined(_MSVC_) && (_MSC_VER >= 1900)
 #pragma optimize( "g", off )
 #endif
 


### PR DESCRIPTION
The gcc optimization around the SRP instruction needs
to be disabled for _MSC_VER >= 1900 instead of only for
_MSC_VER == 1900, as MS VS2017 has _MSC_VER == 2000
and also still exhibits the internal compiler error with
optimization enabled.