### PR TITLE
Stop writing after ETX / ETB in non transparent mode.

### DIFF
--- a/commadpt.c
+++ b/commadpt.c
@@ -3334,20 +3334,29 @@ BYTE    b1, b2;                 /* 2741 overstrike rewriting */
                             {
                                 /* If there was a DLE on previous pass */
                                 if(gotdle)
-                            {
-                                /* check for DLE/ETX */
-                                if(b==0x02)
                                 {
-                                    /* Indicate transparent mode on */
-                                    turnxpar=1;
+                                    /* check for DLE/STX */
+                                    if(b==0x02)
+                                    {
+                                        /* Indicate transparent mode on */
+                                        turnxpar=1;
+                                    }
+                                   gotdle=0;
                                 }
+                                else 
+                                {   
+                                    if((b==0x03) || (b==0x26)) 
+                                    {
+                                        commadpt_ring_push(&dev->commadpt->outbfr,b);
+                                        break;
+                                    }
+                                }   
                             }
                         }
-                    }
-                }  /* end of else (async) */
-                /* Put the current byte on the output ring */
-                commadpt_ring_push(&dev->commadpt->outbfr,b);
-            }
+                    }  /* end of else (async) */
+                    /* Put the current byte on the output ring */
+                    commadpt_ring_push(&dev->commadpt->outbfr,b);
+                }
             if (IS_BSC_LNCTL(dev->commadpt)) 
             {
                 /* If we had a DLE/STX, the line is now in Transparent Write Wait state */


### PR DESCRIPTION
The IBM 2703 Transmission Control Component Description document specifies on
page 58 that a channel write shall stop if an ETX or ETB control character
is detected in the data stream.

It is also mentioned on page 48 in the same document that bytes following the ETX or ETB shall
not be transferred to the line if they are received from the channel.

This fix detects the presence of these characters and breaks out of the loop
if these occur in the data stream.