### PR TITLE
Fix autoconf CPU detection on Raspberry Pi 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,10 +16,12 @@ AM_CONFIG_HEADER(config.h)              # (the file the resulting configure scri
 AM_MAINTAINER_MODE()
 AC_CANONICAL_HOST()                     # (sets $host_cpu, $host_vendor, and $host_os)
 
+# Work around a bug in CPU detection on Cortex CPUs
 AS_IF([test "x$host_cpu" = 'xarmv7l'],[
-       host_cpu=cortex-a53
+       host_cpu=$(LANG=en_US lscpu | grep "Model name" | cut -d: -f2 | tr '[:upper:]' '[:lower:]')
 ])
 AC_SUBST([host_cpu])
+
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 ###############################################################################

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,11 @@ AM_INIT_AUTOMAKE(hercules,3.13)         # (the version of our software package)
 AM_CONFIG_HEADER(config.h)              # (the file the resulting configure script will produce)
 AM_MAINTAINER_MODE()
 AC_CANONICAL_HOST()                     # (sets $host_cpu, $host_vendor, and $host_os)
+
+AS_IF([test "x$host_cpu" = 'xarmv7l'],[
+       host_cpu=cortex-a53
+])
+AC_SUBST([host_cpu])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 ###############################################################################


### PR DESCRIPTION
Autoconf falsely detects an "armv7l" CPU on Cortex-A53
machines like several Raspberry Pi 3 models.

This change works around the issue by correcting the
host_cpu in configure.ac.

See also
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70210
- https://savannah.gnu.org/support/index.php?110360