### PR TITLE
Misleading indentation warnings

### DIFF
--- a/bldcfg.c
+++ b/bldcfg.c
@@ -124,13 +124,15 @@ DLL_EXPORT int parse_args (char* p, int maxargc, char** pargv, int* pargc)
 
     while (*p && *pargc < maxargc)
     {
-        while (*p && isspace(*p)) p++; if (!*p) break; // find start of arg
+        while (*p && isspace(*p)) p++; // find start of arg
+        if (!*p) break;        // give up if no arg present 
 
         if (*p == '#') break; // stop on comments
 
         *pargv = p; ++*pargc; // count new arg
 
-        while (*p && !isspace(*p) && *p != '\"' && *p != '\'') p++; if (!*p) break; // find end of arg
+        while (*p && !isspace(*p) && *p != '\"' && *p != '\'') p++;
+        if (!*p) break; // find end of arg
 
         if (*p == '\"' || *p == '\'')
         {

--- a/dasdcopy.c
+++ b/dasdcopy.c
@@ -363,8 +363,10 @@ char            pgmpath[MAX_PATH];      /* prog path in host format  */
             if (i < max)
                 rc = (idev->hnd->read)(idev, i, &unitstat);
             else
+            {
                 memset (idev->buf, 0, FBA_BLKGRP_SIZE);
                 rc = 0;
+            }
         }
         if (rc < 0)
         {

--- a/hostinfo.c
+++ b/hostinfo.c
@@ -100,7 +100,8 @@ DLL_EXPORT void display_hostinfo ( HOST_INFO* pHostInfo, FILE *f, int httpfd )
     get_hostinfo_str(pHostInfo, host_info_str, sizeof(host_info_str));
     if(httpfd<0)
     {
-        if (!f) f = stdout; if (f != stdout)
+        if (!f) f = stdout;
+        if (f != stdout)
              fprintf(f, "%s\n", host_info_str);
         else logmsg(    "%s\n", host_info_str);
     }

--- a/tapedev.c
+++ b/tapedev.c
@@ -1495,9 +1495,9 @@ void tapedev_query_device ( DEVBLK *dev, char **class,
 
     GetDisplayMsg( dev, dispmsg, sizeof(dispmsg) );
 
-    if (strchr(dev->filename,' ')) strlcat( devparms, "\"",          sizeof(devparms));
-                                   strlcat( devparms, dev->filename, sizeof(devparms));
-    if (strchr(dev->filename,' ')) strlcat( devparms, "\"",          sizeof(devparms));
+    if (strchr(dev->filename,' ')) strlcat( devparms, "\"", sizeof(devparms));
+    strlcat( devparms, dev->filename, sizeof(devparms));
+    if (strchr(dev->filename,' ')) strlcat( devparms, "\"", sizeof(devparms));
 
 #if defined( OPTION_TAPE_AUTOMOUNT )
 


### PR DESCRIPTION
Hello Roger,

This pull request deals with four misleading indentation warnings.  Three of them are cosmetic but the fourth one highlighted an actual bug in dasdcopy.c  There is another indentation warning in ltdl.c which I did not address as I find the code there quite impenetrable and I am not confident of figuring out the authors original intention. 
