### PR TITLE
-Wmaybe-uninitialized warning in tcpnje.c

### DIFF
--- a/tcpnje.c
+++ b/tcpnje.c
@@ -25,7 +25,7 @@
 /* TCPNJE hacked from commadpt by: Peter Coghlan                     */
 /* For further information send mail to software at beyondthepale.ie */
 /*-------------------------------------------------------------------*/
-/* tcpnje version 1.00                                               */
+/* tcpnje version 1.00-x                                               */
 /*-------------------------------------------------------------------*/
 
 #include "hstdinc.h"
@@ -1375,7 +1375,7 @@ static void *tcpnje_thread(void *vtn)
     int maxfd;                  /* highest FD for select             */
     int tn_shutdown;            /* Thread shutdown internal flag     */
     int init_signaled;          /* Thread initialisation signaled    */
-    int TTBlength;              /* Length of TTB in host byte order  */
+    int TTBlength = 0;          /* Length of TTB in host byte order  */
     int eintrcount = 0;         /* Number of times EINTR occured     */
     int errorcount067 = 0;      /* Number of times HHCTN067E issued  */
     int errorcount100 = 0;      /* Number of times HHCTN100E issued  */


### PR DESCRIPTION
Some compilers worry that TTBlength may be used without being initialised in
tcpnje.c.  They do not realise that it will have been given a value on a
previous trip around the loop before it gets used.  This fix initialises
TTBlength to 0 in an effort to keep the compiler from worrying needlessly.