### PR TITLE
avoid bashism in test call

### DIFF
--- a/autoconf/hercules.m4
+++ b/autoconf/hercules.m4
@@ -194,7 +194,7 @@ AC_DEFUN( [HC_GET_C11_LOCK_FREE_VALUE],
 [
     c11_lock_free_name="$1"
 
-    if test "x$c11_lock_free_name" == "x"; then
+    if test "x$c11_lock_free_name" = "x"; then
         # PROGRAMMING NOTE: note special m4 escape syntax used in the below
         # message. Without it, our function name is (infinitely and recursively?)
         # expanded to our actual (as-yet not yet fully defined!) macro VALUE(!),

--- a/configure.ac
+++ b/configure.ac
@@ -562,7 +562,7 @@ AC_CHECK_DECLS( SIOCADDRT,            [hc_cv_have_siocaddrt=yes],           [hc_
 AC_CHECK_DECLS( SIOCDELRT,            [hc_cv_have_siocdelrt=yes],           [hc_cv_have_siocdelrt=no],           [#include <linux/sockios.h>] )
 AC_CHECK_DECLS( SIOCDIFADDR,          [hc_cv_have_siocdifaddr=yes],         [hc_cv_have_siocdifaddr=no],         [#include <linux/sockios.h>] )
 
-if test "$hc_cv_have_sys_mtio_h" == "yes"; then
+if test "$hc_cv_have_sys_mtio_h" = "yes"; then
     AC_CHECK_DECLS( MTEWARN,          [hc_cv_have_mtewarn=yes],             [hc_cv_have_mtewarn=no],             [#include <sys/mtio.h>] )
 else
     hc_cv_have_mtewarn=no


### PR DESCRIPTION
POSIX test only supports =, not ==.