### PR TITLE
HTTP /cgi-bin/tasks/syslog not returning some of syslog.

### DIFF
--- a/cgibin.c
+++ b/cgibin.c
@@ -250,7 +250,7 @@ int     msgcount = 22;
     // Now read the logfile starting at that index. The return
     // value is the total #of bytes of messages data there is.
 
-    if ( (num_bytes = log_read( &logbuf_ptr, &logbuf_idx, LOG_NOBLOCK )) > 0 )
+    while ( (num_bytes = log_read( &logbuf_ptr, &logbuf_idx, LOG_NOBLOCK )) > 0 )
     {
         // Copy the message data to a work buffer for processing.
         // This is to allow for the possibility, however remote,

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@
 AC_INIT(hercules.h)                     # (package, version, bugreport email, etc)
 AC_REVISION($Revision$)          # (the version of this configure.ac)
 AC_CONFIG_AUX_DIR(autoconf)             # (directory containing auxillary build tools)
-AM_INIT_AUTOMAKE(hercules,3.13)         # (the version of our software package)
+AM_INIT_AUTOMAKE(hercules,3.13+H0782)   # (the version of our software package)
 AM_CONFIG_HEADER(config.h)              # (the file the resulting configure script will produce)
 AM_MAINTAINER_MODE()
 AC_CANONICAL_HOST()                     # (sets $host_cpu, $host_vendor, and $host_os)


### PR DESCRIPTION
I use a [program](https://github.com/RossPatterson/PyHercControl) to automate builds of [large VM/CMS projects](https://github.com/RossPatterson/CMS-370-BREXX) under Hercules and the [VM/370 Community Edition](http://vm370.org/).  That program uses the Hercules HTTP server to issue commands and to capture console output.  Everything works, until the log's circular buffer wraps (see SDL Hyperion Issue 792 for the full details).  I originally detected the error in Spinhawk (specifically, the Ubuntu 24.04.3 "hercules" package, version 3.13-7, which Ubuntu inherits from Debian), and it existed in SDL Hyperion until I fixed it a few weeks ago.  The fix is trivial - as the issue notes, the code change is exactly what the block comment in `logger.c:log_line()` recommends.  